### PR TITLE
KB-12 tradeable api

### DIFF
--- a/backend/src/db/pokemon-utils.js
+++ b/backend/src/db/pokemon-utils.js
@@ -85,7 +85,17 @@ export async function createPokemon(ownerId, speciesId, shinyChance = 0.06) {
  * @returns the pokemon with its "species" data populated, or null if not found
  */
 export function retrievePokemonById(id) {
-  return Pokemon.findById(id).populate("species");
+  return Pokemon.findById(id).populate([
+    { path: "species" },
+    {
+      path: "originalOwner",
+      select: "username _id",
+    },
+    {
+      path: "currentOwner",
+      select: "username _id",
+    },
+  ]);
 }
 
 /**
@@ -95,7 +105,17 @@ export function retrievePokemonById(id) {
  * @returns the list of matching pokemon (an empty array if no matches)
  */
 export function retrievePokemonForUser(ownerId) {
-  return Pokemon.find({ owner: ownerId }).populate("species");
+  return Pokemon.find({ currentOwner: ownerId }).populate([
+    { path: "species" },
+    {
+      path: "originalOwner",
+      select: "username _id",
+    },
+    {
+      path: "currentOwner",
+      select: "username _id",
+    },
+  ]);
 }
 
 /**
@@ -108,10 +128,19 @@ export async function updateFavUserPokemon(isFavouriteUpdates, pokeID) {
 }
 
 /**
- * Updates the tradeable field for a user's pokemon (can be used to favourite it or unfavourite)
+ * Updates the tradeable field for a user's pokemon (can be used to tradeable it or un-tradeable)
  * @param {*} pokeID The id of the pokemon to update
  * @returns the updated pokemon
  */
 export async function updateTradeableUserPokemon(isTradeableUpdates, pokeID) {
   return Pokemon.findByIdAndUpdate(pokeID, isTradeableUpdates, { new: true });
+}
+
+/**
+ * Finds how many tradeable pokemon the user has currently.
+ * @param {*} ownerID The id of the pokemon to update
+ * @returns the number of tradeable pokemon a user has currently
+ */
+export async function calculateNumTradeable(ownerID) {
+  return Pokemon.countDocuments({ currentOwner: ownerID, isTradeable: true });
 }

--- a/backend/src/routes/__mocks__/mock_data.js
+++ b/backend/src/routes/__mocks__/mock_data.js
@@ -105,7 +105,7 @@ const pokemonLynneysIvyasaur = {
   currentOwner: new mongoose.Types.ObjectId("000000000000000000000001"),
   isShiny: true,
   isTradeable: false,
-  isFavorite: false,
+  isFavorite: true,
 };
 // Navia's Lunala
 const pokemonNaviasLunala = {
@@ -200,15 +200,15 @@ async function addMockUsers() {
 async function addMockPokemons() {
   const pokemonsDB = mongoose.connection.db.collection("pokemons");
   await pokemonsDB.insertMany([
-    pokemonLynneysIvyasaur, 
+    pokemonLynneysIvyasaur,
     pokemonNaviasLunala,
+    pokemonNaviasIvysaur,
     pokemonNaviasLunalaDup1,
     pokemonNaviasLunalaDup2,
-    pokemonNaviasIvysaur, 
-    pokemonNaviasIvysaurDupe1, 
+    pokemonNaviasIvysaurDupe1,
     pokemonNaviasIvysaurDupe2,
-    pokemonNaviasIvysaurDupe3, 
-    pokemonVentisIvyasaur
+    pokemonNaviasIvysaurDupe3,
+    pokemonVentisIvyasaur,
   ]);
 }
 

--- a/backend/src/routes/__mocks__/mock_data.js
+++ b/backend/src/routes/__mocks__/mock_data.js
@@ -127,6 +127,57 @@ const pokemonNaviasIvysaur = {
   isTradeable: true,
   isFavorite: false,
 };
+// Navia's Lunala
+const pokemonNaviasLunalaDup1 = {
+  _id: new mongoose.Types.ObjectId("000000000000000000000079"),
+  species: new mongoose.Types.ObjectId("000000000000000000000792"),
+  orignialOwner: new mongoose.Types.ObjectId("000000000000000000000002"),
+  currentOwner: new mongoose.Types.ObjectId("000000000000000000000002"),
+  isShiny: false,
+  isTradeable: true,
+  isFavorite: true,
+};
+// Navia's ivysaur
+const pokemonNaviasIvysaurDupe1 = {
+  _id: new mongoose.Types.ObjectId("000000000000000000000080"),
+  species: new mongoose.Types.ObjectId("000000000000000000000020"),
+  orignialOwner: new mongoose.Types.ObjectId("000000000000000000000002"),
+  currentOwner: new mongoose.Types.ObjectId("000000000000000000000002"),
+  isShiny: true,
+  isTradeable: true,
+  isFavorite: false,
+};
+const pokemonNaviasLunalaDup2 = {
+  _id: new mongoose.Types.ObjectId("000000000000000000000081"),
+  species: new mongoose.Types.ObjectId("000000000000000000000792"),
+  orignialOwner: new mongoose.Types.ObjectId("000000000000000000000002"),
+  currentOwner: new mongoose.Types.ObjectId("000000000000000000000002"),
+  isShiny: false,
+  isTradeable: true,
+  isFavorite: true,
+};
+// Navia's ivysaur
+const pokemonNaviasIvysaurDupe2 = {
+  _id: new mongoose.Types.ObjectId("000000000000000000000082"),
+  species: new mongoose.Types.ObjectId("000000000000000000000020"),
+  orignialOwner: new mongoose.Types.ObjectId("000000000000000000000002"),
+  currentOwner: new mongoose.Types.ObjectId("000000000000000000000002"),
+  isShiny: true,
+  isTradeable: true,
+  isFavorite: false,
+};
+
+// Navia's ivysaur
+const pokemonNaviasIvysaurDupe3 = {
+  _id: new mongoose.Types.ObjectId("000000000000000000000083"),
+  species: new mongoose.Types.ObjectId("000000000000000000000020"),
+  orignialOwner: new mongoose.Types.ObjectId("000000000000000000000002"),
+  currentOwner: new mongoose.Types.ObjectId("000000000000000000000002"),
+  isShiny: true,
+  isTradeable: true,
+  isFavorite: false,
+};
+
 // Venti's IvySaur
 const pokemonVentisIvyasaur = {
   _id: new mongoose.Types.ObjectId("000000000000000000000078"),
@@ -148,7 +199,17 @@ async function addMockUsers() {
 }
 async function addMockPokemons() {
   const pokemonsDB = mongoose.connection.db.collection("pokemons");
-  await pokemonsDB.insertMany([pokemonLynneysIvyasaur, pokemonNaviasLunala,pokemonNaviasIvysaur, pokemonVentisIvyasaur]);
+  await pokemonsDB.insertMany([
+    pokemonLynneysIvyasaur, 
+    pokemonNaviasLunala,
+    pokemonNaviasLunalaDup1,
+    pokemonNaviasLunalaDup2,
+    pokemonNaviasIvysaur, 
+    pokemonNaviasIvysaurDupe1, 
+    pokemonNaviasIvysaurDupe2,
+    pokemonNaviasIvysaurDupe3, 
+    pokemonVentisIvyasaur
+  ]);
 }
 
 async function dropData() {

--- a/backend/src/routes/__tests__/pokemons.test.js
+++ b/backend/src/routes/__tests__/pokemons.test.js
@@ -11,6 +11,7 @@ import {
   bearerVenti,
   pokemonNaviasIvysaur,
   pokemonNaviasLunala,
+  pokemonVentisIvyasaur,
   speciesIvysaur,
   speciesLunala,
   userLynney,
@@ -49,8 +50,8 @@ afterAll(async () => {
 describe("Pokemon Tradeable Toggling PATCH /api/v1/pokemons/id/setTradeable", () => {
   test("Successful setting tradeablility of a pokemon", (done) => {
     request(app)
-      .patch(`/api/v1/pokemons/${pokemonNaviasLunala._id}/setTradeable`)
-      .set("Cookie", [`authorization=${bearerNavia}`])
+      .patch(`/api/v1/pokemons/${pokemonVentisIvyasaur._id}/setTradeable`)
+      .set("Cookie", [`authorization=${bearerVenti}`])
       .send({
         isTradeable: true,
       })
@@ -60,10 +61,10 @@ describe("Pokemon Tradeable Toggling PATCH /api/v1/pokemons/id/setTradeable", ()
 
         const fromDb = await mongoose.connection.db
           .collection("pokemons")
-          .findOne({ _id: pokemonNaviasLunala._id });
+          .findOne({ _id: pokemonVentisIvyasaur._id });
         expect(fromDb.isTradeable).toBe(true);
         return done();
-      });
+      }, 10000);
   });
 
   test("Successful removing tradeablility of a pokemon", (done) => {

--- a/backend/src/routes/__tests__/pokemons.test.js
+++ b/backend/src/routes/__tests__/pokemons.test.js
@@ -1,0 +1,137 @@
+import { MongoMemoryServer } from "mongodb-memory-server";
+import mongoose from "mongoose";
+import express from "express";
+import request from "supertest";
+import cookieParser from "cookie-parser";
+import routes from "../pokemons.js";
+import {
+  addAllMockData,
+  bearerLynney,
+  bearerNavia,
+  bearerVenti,
+  pokemonNaviasIvysaur,
+  pokemonNaviasLunala,
+  speciesIvysaur,
+  speciesLunala,
+  userLynney,
+  userNavia,
+  userVenti,
+} from "../__mocks__/mock_data.js";
+
+let mongod, db;
+const app = express();
+app.use(express.json());
+app.use(cookieParser());
+app.use("/api/v1/pokemons", routes);
+
+// Start in-memory DB before tests run
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+
+  const connectionString = mongod.getUri();
+  mongoose.set("strictQuery", false);
+  await mongoose.connect(connectionString);
+  db = mongoose.connection.db;
+});
+
+// Add mock data before each test
+beforeEach(async () => {
+  await addAllMockData();
+});
+
+// Stop in-memory DB when complete
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+// ------- Pokemon Tradeable Toggling -------
+describe("Pokemon Tradeable Toggling PATCH /api/v1/pokemons/id/setTradeable", () => {
+  test("Successful setting tradeablility of a pokemon", (done) => {
+    request(app)
+      .patch(`/api/v1/pokemons/${pokemonNaviasLunala._id}/setTradeable`)
+      .set("Cookie", [`authorization=${bearerNavia}`])
+      .send({
+        isTradeable: true,
+      })
+      .expect(204)
+      .end(async (err, res) => {
+        if (err) return done(err);
+
+        const fromDb = await mongoose.connection.db
+          .collection("pokemons")
+          .findOne({ _id: pokemonNaviasLunala._id });
+        expect(fromDb.isTradeable).toBe(true);
+        return done();
+      });
+  });
+
+  test("Successful removing tradeablility of a pokemon", (done) => {
+    request(app)
+      .patch(`/api/v1/pokemons/${pokemonNaviasIvysaur._id}/setTradeable`)
+      .set("Cookie", [`authorization=${bearerNavia}`])
+      .send({
+        isTradeable: false,
+      })
+      .expect(204)
+      .end(async (err, res) => {
+        if (err) return done(err);
+
+        const fromDb = await mongoose.connection.db
+          .collection("pokemons")
+          .findOne({ _id: pokemonNaviasIvysaur._id });
+        expect(fromDb.isTradeable).toBe(false);
+        return done();
+      });
+  });
+
+  test("No body sent (HTTP 422) - can't change tradeable status", (done) => {
+    request(app)
+      .patch(`/api/v1/pokemons/${pokemonNaviasLunala._id}/setTradeable`)
+      .set("Cookie", [`authorization=${bearerNavia}`])
+      .send()
+      .expect(422)
+      .end(done);
+  });
+  test("Not the owner of the pokemon (HTTP 403) - can't change tradeable", (done) => {
+    request(app)
+      .patch(`/api/v1/pokemons/${pokemonNaviasLunala._id}/setTradeable`)
+      .set("Cookie", [`authorization=${bearerVenti}`])
+      .send({ isTradeable: false })
+      .expect(403)
+      .end(done);
+  });
+  test("Pokemon doesn't exist (HTTP 404) - can't change tradeable", (done) => {
+    request(app)
+      .patch(`/api/v1/pokemons/000000000000000000500009/setTradeable`)
+      .set("Cookie", [`authorization=${bearerNavia}`])
+      .send({ isTradeable: false })
+      .expect(404)
+      .end(done);
+  });
+
+  test("User not authenticated (HTTP 401) - can't change tradeable", (done) => {
+    request(app)
+      .patch(`/api/v1/pokemons/${pokemonNaviasLunala._id}/setTradeable`)
+      .send({ isTradeable: false })
+      .expect(401)
+      .end(done);
+  });
+
+  test("Maximum tradeable Pokemon limit reached (HTTP 403) - can't add more pokemon to be tradeable", (done) => {
+    request(app)
+      .patch(`/api/v1/pokemons/${pokemonNaviasLunala._id}/setTradeable`)
+      .set("Cookie", [`authorization=${bearerNavia}`])
+      .send({ isTradeable: true })
+      .expect(403)
+      .end(done);
+  });
+  test("Maximum tradeable Pokemon limit reached BUT pokemon is already tradeable and want to remove it HTTP(204) ", (done) => {
+    request(app)
+      .patch(`/api/v1/pokemons/${pokemonNaviasIvysaur._id}/setTradeable`)
+      .set("Cookie", [`authorization=${bearerNavia}`])
+      .send({ isTradeable: false })
+      .expect(204)
+      .end(done);
+  });
+});

--- a/backend/src/routes/__tests__/users.test.js
+++ b/backend/src/routes/__tests__/users.test.js
@@ -9,8 +9,11 @@ import {
   addAllMockData,
   bearerLynney,
   bearerNavia,
+  bearerVenti,
+  pokemonLynneysIvyasaur,
   pokemonNaviasIvysaur,
   pokemonNaviasLunala,
+  pokemonVentisIvyasaur,
   speciesIvysaur,
   speciesLunala,
   userLynney,
@@ -116,7 +119,7 @@ describe("Account Registration POST /api/v1/users/register", () => {
           .countDocuments({
             currentOwner: new mongoose.Types.ObjectId(userID),
           });
-        expect(numPokemon).toBe(12);
+        expect(numPokemon).toBe(20);
         return done();
       });
   });
@@ -243,7 +246,7 @@ describe("GET /api/v1/users/:id/pokemon", () => {
       .end((err, res) => {
         if (err) return done(err);
         const pokemon = res.body;
-        expect(pokemon.length).toBe(2);
+        expect(pokemon.length).toBe(7);
         expect(pokemon[0]._id).toBe(pokemonNaviasLunala._id.toString());
         expect(pokemon[1]._id).toBe(pokemonNaviasIvysaur._id.toString());
 
@@ -256,7 +259,7 @@ describe("GET /api/v1/users/:id/pokemon", () => {
 
   test("Successful fetching of another user's pokemon [tradeable only]", (done) => {
     request(app)
-      .get(`/api/v1/users/${userNavia._id}/pokemon`)
+      .get(`/api/v1/users/${userVenti._id}/pokemon`)
       .set("Cookie", [`authorization=${bearerLynney}`])
       .send()
       .expect(200)
@@ -264,7 +267,7 @@ describe("GET /api/v1/users/:id/pokemon", () => {
         if (err) return done(err);
         const pokemon = res.body;
         expect(pokemon.length).toBe(1);
-        expect(pokemon[0]._id).toBe(pokemonNaviasIvysaur._id.toString());
+        expect(pokemon[0]._id).toBe(pokemonVentisIvyasaur._id.toString());
 
         // check if species data is populated
         expect(typeof pokemon[0].species).toBe("object");
@@ -275,35 +278,35 @@ describe("GET /api/v1/users/:id/pokemon", () => {
 
   test("Successful fetching of user's own favorited pokemon", (done) => {
     request(app)
-      .get(`/api/v1/users/${userNavia._id}/pokemon?favoritesOnly=true`)
-      .set("Cookie", [`authorization=${bearerNavia}`])
+      .get(`/api/v1/users/${userLynney._id}/pokemon?favoritesOnly=true`)
+      .set("Cookie", [`authorization=${bearerLynney}`])
       .send()
       .expect(200)
       .end((err, res) => {
         if (err) return done(err);
         const pokemon = res.body;
         expect(pokemon.length).toBe(1);
-        expect(pokemon[0]._id).toBe(pokemonNaviasLunala._id.toString());
+        expect(pokemon[0]._id).toBe(pokemonLynneysIvyasaur._id.toString());
         expect(pokemon[0].isFavorite).toBe(true);
 
         // check if species data is populated
         expect(typeof pokemon[0].species).toBe("object");
-        expect(pokemon[0].species._id).toBe(speciesLunala._id.toString());
+        expect(pokemon[0].species._id).toBe(speciesIvysaur._id.toString());
         return done();
       });
   });
 
   test("Successful fetching of user's own tradeable pokemon", (done) => {
     request(app)
-      .get(`/api/v1/users/${userNavia._id}/pokemon?tradeableOnly=true`)
-      .set("Cookie", [`authorization=${bearerNavia}`])
+      .get(`/api/v1/users/${userVenti._id}/pokemon?tradeableOnly=true`)
+      .set("Cookie", [`authorization=${bearerVenti}`])
       .send()
       .expect(200)
       .end((err, res) => {
         if (err) return done(err);
         const pokemon = res.body;
         expect(pokemon.length).toBe(1);
-        expect(pokemon[0]._id).toBe(pokemonNaviasIvysaur._id.toString());
+        expect(pokemon[0]._id).toBe(pokemonVentisIvyasaur._id.toString());
         expect(pokemon[0].isTradeable).toBe(true);
 
         // check if species data is populated
@@ -315,15 +318,15 @@ describe("GET /api/v1/users/:id/pokemon", () => {
 
   test("Successful fetching of user's own shiny pokemon", (done) => {
     request(app)
-      .get(`/api/v1/users/${userNavia._id}/pokemon?shinyOnly=true`)
-      .set("Cookie", [`authorization=${bearerNavia}`])
+      .get(`/api/v1/users/${userVenti._id}/pokemon?shinyOnly=true`)
+      .set("Cookie", [`authorization=${bearerVenti}`])
       .send()
       .expect(200)
       .end((err, res) => {
         if (err) return done(err);
         const pokemon = res.body;
         expect(pokemon.length).toBe(1);
-        expect(pokemon[0]._id).toBe(pokemonNaviasIvysaur._id.toString());
+        expect(pokemon[0]._id).toBe(pokemonVentisIvyasaur._id.toString());
         expect(pokemon[0].isShiny).toBe(true);
 
         // check if species data is populated

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -1,8 +1,10 @@
 import express from 'express';
 import user from './users.js';
+import pokemon from "./pokemons.js";
 
 const router = express.Router();
 router.use("/users", user);
+router.use("/pokemons", pokemon);
 
 
 export default router;

--- a/backend/src/routes/pokemons.js
+++ b/backend/src/routes/pokemons.js
@@ -35,8 +35,6 @@ router.patch("/:id/setTradeable", auth, async (req, res) => {
           "Maximum tradeable Pokemon limit reached. Only 6 Pokemon can be marked as tradeable."
         );
     }
-    console.log(numTradeable);
-    console.log(pokemon.isTradeable);
 
     const update = await updateTradeableUserPokemon(
       tradeableUpdates,

--- a/backend/src/routes/pokemons.js
+++ b/backend/src/routes/pokemons.js
@@ -28,13 +28,15 @@ router.patch("/:id/setTradeable", auth, async (req, res) => {
     }
 
     const numTradeable = await calculateNumTradeable(req.user._id);
-    if (numTradeable >= 6) {
+    if (numTradeable >= 6 && !pokemon.isTradeable) {
       return res
         .status(403)
         .send(
           "Maximum tradeable Pokemon limit reached. Only 6 Pokemon can be marked as tradeable."
         );
     }
+    console.log(numTradeable);
+    console.log(pokemon.isTradeable);
 
     const update = await updateTradeableUserPokemon(
       tradeableUpdates,

--- a/backend/src/routes/pokemons.js
+++ b/backend/src/routes/pokemons.js
@@ -1,0 +1,50 @@
+import express from "express";
+import auth from "../auth/auth.js";
+import {
+  retrievePokemonForUser,
+  retrievePokemonById,
+  updateFavUserPokemon,
+  updateTradeableUserPokemon,
+  calculateNumTradeable,
+} from "../db/pokemon-utils.js";
+
+const router = express.Router();
+
+// Updating the tradeable status of an owner's pokemon.
+// Users can only update this field if they are the current owner of the pokemon.
+// At most 6 pokemon can be listed as tradeable.
+router.patch("/:id/setTradeable", auth, async (req, res) => {
+  try {
+    const tradeableUpdates = req.body;
+    const pokemon = await retrievePokemonById(req.params.id);
+
+    if (Object.keys(req.body).length === 0) {
+      return res.status(422).send("Empty request body");
+    }
+
+    if (!pokemon) return res.status(404).send("Pokemon can not be found.");
+    if (!pokemon.currentOwner.equals(req.user._id)) {
+      return res.status(403).send("Pokemon is not owned by user.");
+    }
+
+    const numTradeable = await calculateNumTradeable(req.user._id);
+    if (numTradeable >= 6) {
+      return res
+        .status(403)
+        .send(
+          "Maximum tradeable Pokemon limit reached. Only 6 Pokemon can be marked as tradeable."
+        );
+    }
+
+    const update = await updateTradeableUserPokemon(
+      tradeableUpdates,
+      req.params.id
+    );
+    return res.sendStatus(204);
+  } catch (error) {
+    console.error("Error updating tradeable status:", error);
+    return res.status(500).send("Internal Server Error");
+  }
+});
+
+export default router;


### PR DESCRIPTION
- Added endpoint for toggling tradeability of a pokemon
- Owner data can now be fetched along side the pokemon.
- Added unit tests for that endpoint (`/api/v1/pokemons/:id/setTradeable`)
- Fixed unit test for `/api/v1/pokemons/:id/setTradeable`
- Fixed unit tests for `/api/v1/users/:id/pokemon` to use updated mock data.