### PR TITLE
KB-15 incubator API

### DIFF
--- a/backend/src/db/incubator-schema.js
+++ b/backend/src/db/incubator-schema.js
@@ -1,0 +1,38 @@
+import mongoose from "mongoose";
+
+const Schema = mongoose.Schema;
+
+/**
+ * Schema for incubators. An incubator has a pokemon and an owner
+ */
+const incubatorSchema = new Schema({
+  hatcher: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "User",
+    required: true,
+  },
+  hatchTime: {
+    type: Date,
+    required: true,
+  },
+  hatched: {
+    type: Boolean,
+    default: false,
+  },
+  isLegendary: {
+    type: Boolean,
+    required: true,
+  },
+  pokemonType: {
+    type: String,
+    required: true,
+  },
+  species: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "Species",
+    required: true,
+  },
+});
+
+const Incubator = mongoose.model("Incubator", incubatorSchema);
+export default Incubator;

--- a/backend/src/db/incubator-schema.js
+++ b/backend/src/db/incubator-schema.js
@@ -15,10 +15,6 @@ const incubatorSchema = new Schema({
     type: Date,
     required: true,
   },
-  hatched: {
-    type: Boolean,
-    default: false,
-  },
   isLegendary: {
     type: Boolean,
     required: true,
@@ -33,6 +29,7 @@ const incubatorSchema = new Schema({
     required: true,
   },
 });
+//egg image? not sure if i want to host it on server or local
 
 const Incubator = mongoose.model("Incubator", incubatorSchema);
 export default Incubator;

--- a/backend/src/db/incubator-utils.js
+++ b/backend/src/db/incubator-utils.js
@@ -56,5 +56,5 @@ export function isValidPokemonType(type) {
     "steel",
     "fairy",
   ];
-  return validPokemonTypes.includes(type.toLowercase());
+  return validPokemonTypes.includes(String(type).toLowerCase());
 }

--- a/backend/src/db/incubator-utils.js
+++ b/backend/src/db/incubator-utils.js
@@ -1,4 +1,4 @@
-import Incubator from "./incubator-schema";
+import Incubator from "./incubator-schema.js";
 
 /**
  * Gets incubators for the given user
@@ -8,6 +8,16 @@ import Incubator from "./incubator-schema";
  */
 export function retrieveIncubatorsForUser(userID) {
   return Incubator.find({ hatcher: userID });
+}
+
+/**
+ * Gets a specific incubator for the given user
+ *
+ * @param {*} incubatorId The incubator to fetch
+ * @returns the specified incubator
+ */
+export function findIncubatorById(incubatorId) {
+  return Incubator.find({ _id: incubatorId }).populate({ path: "species" });
 }
 
 export function isLegendaryEggProbability() {

--- a/backend/src/db/incubator-utils.js
+++ b/backend/src/db/incubator-utils.js
@@ -17,7 +17,7 @@ export function retrieveIncubatorsForUser(userID) {
  * @returns the specified incubator
  */
 export function findIncubatorById(incubatorId) {
-  return Incubator.find({ _id: incubatorId }).populate({ path: "species" });
+  return Incubator.findById(incubatorId).populate({ path: "species" });
 }
 
 export function isLegendaryEggProbability() {

--- a/backend/src/db/incubator-utils.js
+++ b/backend/src/db/incubator-utils.js
@@ -1,0 +1,50 @@
+import Incubator from "./incubator-schema";
+
+/**
+ * Gets incubators for the given user
+ *
+ * @param {*} userId the user whose incubators to fetch
+ * @returns the list of matching incubators (an empty array if no matches)
+ */
+export function retrieveIncubatorsForUser(userID) {
+  return Incubator.find({ hatcher: userID });
+}
+
+export function isLegendaryEggProbability() {
+  const probabilities = {
+    common: 0.7,
+    legendary: 0.08,
+  };
+
+  const random = Math.random();
+
+  if (random < probabilities.legendary) {
+    return true;
+  }
+
+  return false;
+}
+
+export function isValidPokemonType(type) {
+  const validPokemonTypes = [
+    "normal",
+    "fire",
+    "water",
+    "electric",
+    "grass",
+    "ice",
+    "fighting",
+    "poison",
+    "ground",
+    "flying",
+    "psychic",
+    "bug",
+    "rock",
+    "ghost",
+    "dragon",
+    "dark",
+    "steel",
+    "fairy",
+  ];
+  return validPokemonTypes.includes(type.toLowercase());
+}

--- a/backend/src/db/species-utils.js
+++ b/backend/src/db/species-utils.js
@@ -14,5 +14,5 @@ export function getSpeciesByFilter(filter) {
 
 export function getRandomSpeciesFromList(speciesList) {
   const randomIndex = Math.floor(Math.random() * speciesList.length);
-  return pokemonList[randomIndex];
+  return speciesList[randomIndex];
 }

--- a/backend/src/db/species-utils.js
+++ b/backend/src/db/species-utils.js
@@ -1,0 +1,18 @@
+import Species from "./species-schema.js";
+import User from "./user-schema.js";
+
+/**
+ * Gets species by a filter. Ideally used for finding species of specific types
+ * and/or rarity (legendary or not)
+ *
+ * @param {*} filter the filter applied
+ * @returns the list of matching species (an empty array if no matches)
+ */
+export function getSpeciesByFilter(filter) {
+  return Species.find(filter);
+}
+
+export function getRandomSpeciesFromList(speciesList) {
+  const randomIndex = Math.floor(Math.random() * speciesList.length);
+  return pokemonList[randomIndex];
+}

--- a/backend/src/routes/__mocks__/mock_data.js
+++ b/backend/src/routes/__mocks__/mock_data.js
@@ -2,6 +2,23 @@ import mongoose, { mongo } from "mongoose";
 import jwt from "jsonwebtoken";
 
 // --------- Species ---------
+const speciesShaymin = {
+  _id: new mongoose.Types.ObjectId("000000000000000000000492"),
+  dexNumber: 492,
+  dexEntry:
+    "It lives in flower patches and avoids detection by curling up to look like a flowering plant.",
+  name: "shaymin",
+  types: ["grass"],
+  height: 2,
+  weight: 21,
+  isLegendary: true,
+  image: {
+    normal:
+      "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/492.png",
+    shiny:
+      "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/shiny/492.png",
+  },
+};
 
 const speciesIvysaur = {
   _id: new mongoose.Types.ObjectId("000000000000000000000020"),
@@ -199,10 +216,53 @@ const pokemonVentisLunala = {
   isLocked: false,
 };
 
+// --------- Incubators ---------
+// Venti's incubators can be useful for not allowing
+// adding incubators when there are already 4 active.
+const ventisIncubatorGhost = {
+  _id: new mongoose.Types.ObjectId("000000000000000000003562"),
+  hatcher: new mongoose.Types.ObjectId("000000000000000000000003"),
+  // 1716069600 = Sun May 19 2024 10:00:00 GMT+1200 (New Zealand Standard Time)
+  hatchTime: new Date(1716069600),
+  hatched: false,
+  isLegendary: true,
+  pokemonType: "ghost",
+  species: new mongoose.Types.ObjectId("000000000000000000000792"),
+};
+const ventisIncubatorGrass = {
+  _id: new mongoose.Types.ObjectId("000000000000000000003563"),
+  hatcher: new mongoose.Types.ObjectId("000000000000000000000003"),
+  hatchTime: new Date(),
+  hatched: false,
+  isLegendary: false,
+  pokemonType: "grass",
+  species: new mongoose.Types.ObjectId("000000000000000000000020"),
+};
+
+const ventisIncubatorGrassDupe1 = {
+  _id: new mongoose.Types.ObjectId("000000000000000000003564"),
+  hatcher: new mongoose.Types.ObjectId("000000000000000000000003"),
+  hatchTime: new Date(),
+  hatched: false,
+  isLegendary: false,
+  pokemonType: "grass",
+  species: new mongoose.Types.ObjectId("000000000000000000000020"),
+};
+
+const ventisIncubatorGrassDupe2 = {
+  _id: new mongoose.Types.ObjectId("000000000000000000003565"),
+  hatcher: new mongoose.Types.ObjectId("000000000000000000000003"),
+  hatchTime: new Date(),
+  hatched: false,
+  isLegendary: false,
+  pokemonType: "grass",
+  species: new mongoose.Types.ObjectId("000000000000000000000020"),
+};
+
 // --------- Functions ---------
 async function addMockSpecies() {
   const speciesDB = mongoose.connection.db.collection("species");
-  await speciesDB.insertMany([speciesIvysaur, speciesLunala]);
+  await speciesDB.insertMany([speciesShaymin, speciesIvysaur, speciesLunala]);
 }
 async function addMockUsers() {
   const usersDB = mongoose.connection.db.collection("users");
@@ -224,6 +284,16 @@ async function addMockPokemons() {
   ]);
 }
 
+async function addMockIncubators() {
+  let incubatorDB = mongoose.connection.db.collection("incubators");
+  await incubatorDB.insertMany([
+    ventisIncubatorGhost,
+    ventisIncubatorGrass,
+    ventisIncubatorGrassDupe1,
+    ventisIncubatorGrassDupe2,
+  ]);
+}
+
 async function dropData() {
   const collections = await mongoose.connection.db.collections();
   for (const collection of collections) {
@@ -236,11 +306,13 @@ async function addAllMockData() {
   await addMockSpecies();
   await addMockUsers();
   await addMockPokemons();
+  await addMockIncubators();
 }
 
 export {
   speciesIvysaur,
   speciesLunala,
+  speciesShaymin,
   userLynney,
   userNavia,
   userVenti,
@@ -252,5 +324,7 @@ export {
   pokemonNaviasIvysaur,
   pokemonVentisIvyasaur,
   pokemonVentisLunala,
+  ventisIncubatorGhost,
+  ventisIncubatorGrass,
   addAllMockData,
 };

--- a/backend/src/routes/__mocks__/mock_data.js
+++ b/backend/src/routes/__mocks__/mock_data.js
@@ -286,6 +286,15 @@ async function addMockPokemons() {
 
 async function addMockIncubators() {
   let incubatorDB = mongoose.connection.db.collection("incubators");
+  ventisIncubatorGrass.hatchTime.setHours(
+    ventisIncubatorGrass.hatchTime.getHours() + 3
+  );
+  ventisIncubatorGrassDupe1.hatchTime.setHours(
+    ventisIncubatorGrass.hatchTime.getHours() + 3
+  );
+  ventisIncubatorGrassDupe2.hatchTime.setHours(
+    ventisIncubatorGrass.hatchTime.getHours() + 3
+  );
   await incubatorDB.insertMany([
     ventisIncubatorGhost,
     ventisIncubatorGrass,

--- a/backend/src/routes/__tests__/incubators.test.js
+++ b/backend/src/routes/__tests__/incubators.test.js
@@ -115,7 +115,7 @@ describe("Incubator Creation POST /api/v1/incubators/:type/create", () => {
 });
 
 // ---------------- Incubator Hatching ----------------
-describe("Incubator Creation DELETE /api/v1/incubators/:id/hatch", () => {
+describe("Incubator Hatching DELETE /api/v1/incubators/:id/hatch", () => {
   test("Successful hatching of an incubator", (done) => {
     request(app)
       .delete(`/api/v1/incubators/${ventisIncubatorGhost._id}/hatch`)
@@ -151,6 +151,43 @@ describe("Incubator Creation DELETE /api/v1/incubators/:id/hatch", () => {
   test("User not authenticated (HTTP 401) - can't hatch egg", (done) => {
     request(app)
       .delete(`/api/v1/incubators/${ventisIncubatorGhost._id}/hatch`)
+      .send()
+      .expect(401)
+      .end(done);
+  });
+});
+
+// ---------------- Incubator Cancel ----------------
+describe("Incubator Cancel DELETE /api/v1/incubators/:id/cancel", () => {
+  test("Successful cancelation of an incubator", (done) => {
+    request(app)
+      .delete(`/api/v1/incubators/${ventisIncubatorGhost._id}/cancel`)
+      .set("Cookie", [`authorization=${bearerVenti}`])
+      .send()
+      .expect(200)
+      .end(async (err, res) => {
+        if (err) return done(err);
+        const incubatorExist = await mongoose.connection.db
+          .collection("incubators")
+          .findOne({ _id: ventisIncubatorGhost._id });
+
+        expect(incubatorExist).toBeNull();
+        return done();
+      });
+  });
+
+  test("Non-existent incubator (HTTP 404)", (done) => {
+    request(app)
+      .delete("/api/v1/incubators/000000000000000000000000/cancel")
+      .set("Cookie", [`authorization=${bearerVenti}`])
+      .send()
+      .expect(404)
+      .end(done);
+  });
+
+  test("User not authenticated (HTTP 401) - can't cancel incubation", (done) => {
+    request(app)
+      .delete(`/api/v1/incubators/${ventisIncubatorGhost._id}/cancel`)
       .send()
       .expect(401)
       .end(done);

--- a/backend/src/routes/__tests__/incubators.test.js
+++ b/backend/src/routes/__tests__/incubators.test.js
@@ -81,6 +81,10 @@ describe("Incubator Fetch GET /api/v1/incubators/", () => {
         return done();
       });
   });
+
+  test("User not authenticated (HTTP 401) - can't fetch incubators", (done) => {
+    request(app).get(`/api/v1/incubators/`).send().expect(401).end(done);
+  });
 });
 
 // ---------------- Incubator Creation ----------------
@@ -106,6 +110,14 @@ describe("Incubator Creation POST /api/v1/incubators/:type/create", () => {
       .set("Cookie", [`authorization=${bearerVenti}`])
       .send()
       .expect(403)
+      .end(done);
+  });
+
+  test("User not authenticated (HTTP 401) - can't create incubators", (done) => {
+    request(app)
+      .post("/api/v1/incubators/grass/create")
+      .send()
+      .expect(401)
       .end(done);
   });
 });

--- a/backend/src/routes/__tests__/incubators.test.js
+++ b/backend/src/routes/__tests__/incubators.test.js
@@ -1,0 +1,111 @@
+import { MongoMemoryServer } from "mongodb-memory-server";
+import mongoose from "mongoose";
+import express from "express";
+import request from "supertest";
+import cookieParser from "cookie-parser";
+import routes from "../incubators.js";
+import {
+  addAllMockData,
+  bearerLynney,
+  bearerNavia,
+  bearerVenti,
+  pokemonLynneysIvyasaur,
+  pokemonNaviasIvysaur,
+  pokemonNaviasLunala,
+  pokemonVentisIvyasaur,
+  speciesIvysaur,
+  speciesLunala,
+  userLynney,
+  userNavia,
+  userVenti,
+  ventisIncubatorGhost,
+  ventisIncubatorGrass,
+} from "../__mocks__/mock_data.js";
+
+let mongod, db;
+const app = express();
+app.use(express.json());
+app.use(cookieParser());
+app.use("/api/v1/incubators", routes);
+
+// Start in-memory DB before tests run
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+
+  const connectionString = mongod.getUri();
+  mongoose.set("strictQuery", false);
+  await mongoose.connect(connectionString);
+  db = mongoose.connection.db;
+});
+
+// Add mock data before each test
+beforeEach(async () => {
+  await addAllMockData();
+});
+
+// Stop in-memory DB when complete
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+// ---------------- Incubator Fetching ----------------
+describe("Incubator Fetch GET /api/v1/incubators/", () => {
+  test("Successful fetching of incubators", (done) => {
+    request(app)
+      .get("/api/v1/incubators/")
+      .set("Cookie", [`authorization=${bearerVenti}`])
+      .send()
+      .expect(200)
+      .end((err, res) => {
+        if (err) return done(err);
+        let incubators = res.body;
+        expect(incubators.length).toBe(4);
+        expect(incubators[0]._id).toBe(ventisIncubatorGhost._id.toString());
+        expect(incubators[1]._id).toBe(ventisIncubatorGrass._id.toString());
+
+        return done();
+      });
+  });
+  test("Successful fetching of no incubators when user doesn't have any", (done) => {
+    request(app)
+      .get("/api/v1/incubators/")
+      .set("Cookie", [`authorization=${bearerNavia}`])
+      .send()
+      .expect(200)
+      .end((err, res) => {
+        if (err) return done(err);
+        let incubators = res.body;
+        expect(incubators.length).toBe(0);
+
+        return done();
+      });
+  });
+});
+
+// ---------------- Incubator Creation ----------------
+describe("Incubator Creation POST /api/v1/incubators/:type/create", () => {
+  test("Successful creation of incubator for grass type eggs", (done) => {
+    request(app)
+      .post("/api/v1/incubators/grass/create")
+      .set("Cookie", [`authorization=${bearerLynney}`])
+      .send()
+      .expect(201)
+      .end((err, res) => {
+        if (err) return done(err);
+        let { success, incubator } = res.body;
+        expect(success).toBe(true);
+        console.log(incubator);
+        expect(incubator.pokemonType).toBe("grass");
+        return done();
+      });
+  });
+  test("Maximum incubator limit (HTTP 403) - can't add anymore incubators", (done) => {
+    request(app)
+      .post("/api/v1/incubators/grass/create")
+      .set("Cookie", [`authorization=${bearerVenti}`])
+      .send()
+      .expect(403)
+      .end(done);
+  });
+});

--- a/backend/src/routes/__tests__/incubators.test.js
+++ b/backend/src/routes/__tests__/incubators.test.js
@@ -9,15 +9,7 @@ import {
   bearerLynney,
   bearerNavia,
   bearerVenti,
-  pokemonLynneysIvyasaur,
-  pokemonNaviasIvysaur,
-  pokemonNaviasLunala,
-  pokemonVentisIvyasaur,
-  speciesIvysaur,
   speciesLunala,
-  userLynney,
-  userNavia,
-  userVenti,
   ventisIncubatorGhost,
   ventisIncubatorGrass,
 } from "../__mocks__/mock_data.js";
@@ -116,6 +108,49 @@ describe("Incubator Creation POST /api/v1/incubators/:type/create", () => {
   test("User not authenticated (HTTP 401) - can't create incubators", (done) => {
     request(app)
       .post("/api/v1/incubators/grass/create")
+      .send()
+      .expect(401)
+      .end(done);
+  });
+});
+
+// ---------------- Incubator Hatching ----------------
+describe("Incubator Creation DELETE /api/v1/incubators/:id/hatch", () => {
+  test("Successful hatching of an incubator", (done) => {
+    request(app)
+      .delete(`/api/v1/incubators/${ventisIncubatorGhost._id}/hatch`)
+      .set("Cookie", [`authorization=${bearerVenti}`])
+      .send()
+      .expect(200)
+      .end((err, res) => {
+        if (err) return done(err);
+        let { success, pokemon } = res.body;
+        expect(success).toBe(true);
+        expect(pokemon.species._id).toBe(speciesLunala._id.toString());
+        return done();
+      });
+  });
+  test("Unsuccessful hatching of an egg (HTTP 403) - time hasn't elapsed", (done) => {
+    request(app)
+      .delete(`/api/v1/incubators/${ventisIncubatorGrass._id}/hatch`)
+      .set("Cookie", [`authorization=${bearerVenti}`])
+      .send()
+      .expect(403)
+      .end(done);
+  });
+
+  test("Non-existent incubator (HTTP 404)", (done) => {
+    request(app)
+      .delete("/api/v1/incubators/000000000000000000000000/hatch")
+      .set("Cookie", [`authorization=${bearerVenti}`])
+      .send()
+      .expect(404)
+      .end(done);
+  });
+
+  test("User not authenticated (HTTP 401) - can't hatch egg", (done) => {
+    request(app)
+      .delete(`/api/v1/incubators/${ventisIncubatorGhost._id}/hatch`)
       .send()
       .expect(401)
       .end(done);

--- a/backend/src/routes/incubators.js
+++ b/backend/src/routes/incubators.js
@@ -1,0 +1,68 @@
+import express from "express";
+import auth from "../auth/auth.js";
+import {
+  retrievePokemonForUser,
+  retrievePokemonById,
+  updateFavUserPokemon,
+  updateTradeableUserPokemon,
+  calculateNumTradeable,
+} from "../db/pokemon-utils.js";
+import {
+  getRandomSpeciesFromList,
+  getSpeciesByFilter,
+} from "../db/species-utils.js";
+import {
+  isLegendaryEggProbability,
+  retrieveIncubatorsForUser,
+} from "../db/incubator-utils.js";
+import Incubator from "../db/incubator-schema.js";
+
+const router = express.Router();
+// Get all incubators related to user
+router.get("/", auth, async (req, res) => {
+  const incubators = await retrieveIncubatorsForUser(userID);
+  return res.json(incubators);
+});
+
+// create new incubators based on type choosen.
+router.post("/:type/create", auth, async (req, res) => {
+  try {
+    const type = req.params;
+    const userID = req.user._id;
+    if (!isValidPokemonType(type))
+      return res.status(422).send("Not a valid pokemon type.");
+    const incubators = await retrieveIncubatorsForUser(userID);
+    if (incubators.length > 4) {
+      return res
+        .status(403)
+        .send(
+          "Maximum limit of incubators reached. Only 4 incubators can be active at any time."
+        );
+    }
+
+    const isLegendary = isLegendaryEggProbability();
+    let generatedSpecies;
+    const speciesFilter = { types: { $in: type }, isLegendary: isLegendary };
+    const speciesList = getSpeciesByFilter(speciesFilter);
+
+    generatedSpecies = getRandomSpeciesFromList(speciesList);
+    console.log(species);
+    const hatchTime = new Date();
+    hatchTime.setHours(hatchTime.getHours() + isLegendary ? 6 : 3);
+
+    const incubator = await Incubator.create({
+      hatcher: userID,
+      hatchTime: hatchTime,
+      hatched: false,
+      isLegendary: isLegendary,
+      pokemonType: type,
+      species: generatedSpecies._id,
+    });
+    return res.status(201).json({ success: true, incubator });
+  } catch (error) {
+    console.error("Error creating incubator: ", error);
+    return res.status(500).send("Internal Server Error");
+  }
+});
+
+export default router;

--- a/backend/src/routes/incubators.js
+++ b/backend/src/routes/incubators.js
@@ -127,7 +127,7 @@ router.delete("/:id/cancel", auth, async (req, res) => {
     const result = await Incubator.deleteOne({ _id: req.params.id });
 
     if (result.deletedCount === 1) {
-      return res.status(200);
+      return res.sendStatus(200);
     } else {
       throw "No documents matched query. Deleted 0 documents.";
     }

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -1,10 +1,12 @@
 import express from 'express';
 import user from './users.js';
 import pokemon from "./pokemons.js";
+import incubator from "./incubators.js";
 
 const router = express.Router();
 router.use("/users", user);
 router.use("/pokemons", pokemon);
+router.use("/incubators", incubator);
 
 
 export default router;


### PR DESCRIPTION
Added endpoints for incubator functionality.
- GET`/api/v1/incubators/` - Fetches all incubators related to user
- POST `/api/v1/incubators/:type/create` - Create new incubators based on type chosen
- DELETE `/api/v1/incubators/:id/hatch` - Hatch the egg in the incubator, create new pokemon for user and delete the incubator.
- DELETE `/api/v1/incubators/:id/cancel` - Cancel and delete the incubator.