### PR TITLE
KB-29 wishlist api

### DIFF
--- a/backend/src/db/user-schema.js
+++ b/backend/src/db/user-schema.js
@@ -12,6 +12,14 @@ const userSchema = new Schema({
   email: { type: String, unique: true, required: true },
   passHash: { type: String, required: true },
   image: { type: String },
+  wishlist: [
+    {
+      species: {
+        type: Schema.Types.ObjectId,
+        ref: "Species",
+      },
+    },
+  ],
 });
 
 const User = mongoose.model("User", userSchema);

--- a/backend/src/routes/__mocks__/mock_data.js
+++ b/backend/src/routes/__mocks__/mock_data.js
@@ -118,6 +118,20 @@ const userLynney = {
   passHash: "$2a$12$GUoBELgxZwgU2MwhZQDVresoxBzaSOTZTat157F0KaHjoBGEI3yKO",
   image:
     "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/792.png",
+  wishlist: [
+    {
+      species: speciesBulbasaur._id,
+      _id: new mongoose.Types.ObjectId("000000000000710000000001"),
+    },
+    {
+      species: speciesLunala._id,
+      _id: new mongoose.Types.ObjectId("000000000000720000000001"),
+    },
+    {
+      species: speciesVenusaur._id,
+      _id: new mongoose.Types.ObjectId("000000000000730000000001"),
+    },
+  ],
 };
 
 // Valid token for Lynney - for authetication checks
@@ -136,6 +150,7 @@ const userNavia = {
   passHash: "$2a$12$GUoBELgxZwgU2MwhZQDVresoxBzaSOTZTat157F0KaHjoBGEI3yKO",
   image:
     "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/792.png",
+  wishlist: [],
 };
 
 // Valid token for Navia - for authetication checks
@@ -154,6 +169,7 @@ const userVenti = {
   passHash: "$2a$12$GUoBELgxZwgU2MwhZQDVresoxBzaSOTZTat157F0KaHjoBGEI3yKO",
   image:
     "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/792.png",
+  wishlist: [],
 };
 
 // Valid token for Navia - for authetication checks
@@ -172,6 +188,7 @@ const userAgatha = {
   passHash: "$2a$12$GUoBELgxZwgU2MwhZQDVresoxBzaSOTZTat157F0KaHjoBGEI3yKO",
   image:
     "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/792.png",
+  wishlist: [],
 };
 
 // Valid token for Agatha - for authetication checks

--- a/frontend/toge-trades/src/components/pokedex/pokedex-card/PokedexCard.jsx
+++ b/frontend/toge-trades/src/components/pokedex/pokedex-card/PokedexCard.jsx
@@ -18,7 +18,7 @@ export default function PokedexCard({ species }) {
         <a
           data-tooltip-id="pokedex-tooltips"
           data-tooltip-content={`You ${
-            species.isMissing ? "don't own" : "own"
+            species.isMissing ? "don't own" : "own or haved owned"
           } ${capitalizeFirstLetter(species.name)}`}
         >
           <img


### PR DESCRIPTION
- [FIX KB-17: Adjusted GET /api/v1/species/ to return isMissing if user currently owned or was the original owner of the pokemon](https://github.com/rnat697/togetrades/commit/cb4ce579efec3640251086cb3ea165b03c0a443d) 
- [FEAT KB-29: Added wishlist endpoints for `GET /api/v1/users/:id/wishlist`, `POST /api/v1/users/wishlist/add` and `DELETE /api/v1/users/wishlist/remove`](https://github.com/rnat697/togetrades/commit/955d5e8bf01586774b8edb8c855c5ddc73ee4c61) 



