### PR TITLE
KB-19 trade hub recent listings frontend

### DIFF
--- a/backend/src/routes/listing.js
+++ b/backend/src/routes/listing.js
@@ -107,7 +107,7 @@ router.get("/", auth, async (req, res) => {
     // Paginations
     const page = parseInt(req.query.page) || 1;
     if (page <= 0) page = 1;
-    const limit = parseInt(req.query.limit, 10) || 20;
+    const limit = parseInt(req.query.limit, 10) || 10;
     const skip = (page - 1) * limit;
     // fetch all listings (active)
     const listings = await Listing.find({ status: "Active" })

--- a/frontend/toge-trades/src/App.jsx
+++ b/frontend/toge-trades/src/App.jsx
@@ -35,6 +35,7 @@ function App() {
   return (
     <Routes>
       <Route path="/" element={<PageLayout />}>
+        <Route path="*" element={<Navigate to="/landing" replace />} />
         <Route index element={<Navigate to="landing" replace />} />
         <Route
           path="landing"
@@ -68,7 +69,7 @@ function App() {
             </RequiresAuth>
           }
         />
-        <Route index element={<Navigate to="/pokebox/1" replace />} />
+        <Route path="pokebox" element={<Navigate to="/pokebox/1" replace />} />
         <Route
           path="incubator"
           element={
@@ -93,7 +94,7 @@ function App() {
             </RequiresAuth>
           }
         />
-        <Route index element={<Navigate to="/pokedex/1" replace />} />
+        <Route path="pokedex" element={<Navigate to="/pokedex/1" replace />} />
         <Route
           path="pokedex/entry/:dexNumber"
           element={
@@ -104,12 +105,16 @@ function App() {
         />
         <Route index element={<Navigate to="/pokedex/entry/1" replace />} />
         <Route
-          path="tradehub"
+          path="tradehub/:page?"
           element={
             <RequiresAuth>
               <TradeHubPage />
             </RequiresAuth>
           }
+        />
+        <Route
+          path="tradehub"
+          element={<Navigate to="/tradehub/1" replace />}
         />
       </Route>
     </Routes>

--- a/frontend/toge-trades/src/Pages/Trade-hub/TradeHubPage.jsx
+++ b/frontend/toge-trades/src/Pages/Trade-hub/TradeHubPage.jsx
@@ -37,7 +37,7 @@ export default function TradeHubPage() {
   const handleOfferModalClose = () => {
     setShowOffer(false);
   };
-  const handleOfferModalConfirm = (pokemon, isSeekingShiny) => {
+  const handleOfferModalConfirm = (pokemon) => {
     setShowOffer(false);
     setPokemon(pokemon);
   };
@@ -54,6 +54,17 @@ export default function TradeHubPage() {
     setPokemon(null);
     setSpecies(null);
     setIsSeekingShiny(false);
+  };
+
+  // --- Handle Refresh ---
+  const handleRefresh = () => {
+    refresh();
+  };
+  // --- Handle page change ---
+  const handlePageChange = ({ selected }) => {
+    setCurrentPage(selected + 1); // react-paginate uses 0-based index
+    navigate(`/tradehub/${selected + 1}`); // Update the URL
+    window.scrollTo(0, 0);
   };
 
   return (
@@ -89,15 +100,11 @@ export default function TradeHubPage() {
         />
         <div className={styles["hub-title-listings"]}>
           <h3>Recent Listings</h3>
-          <button>Refresh</button>
+          <button onClick={handleRefresh}>Refresh</button>
         </div>
         <div className={styles["hub-listings"]}>
           {listings.map((listing) => (
-            <ListingCards
-              key={listing.id}
-              listing={listing}
-              // isInMyListings={true}
-            />
+            <ListingCards key={listing.id} listing={listing} />
           ))}
           {isLoading && (
             <div className="pokebox-loader">
@@ -112,6 +119,21 @@ export default function TradeHubPage() {
             </div>
           )}
         </div>
+        <ReactPaginate
+          breakLabel="..."
+          nextLabel=">"
+          pageRangeDisplayed={5}
+          onPageChange={handlePageChange}
+          pageCount={listingsMetadata?.totalPages ?? 1}
+          previousLabel="<"
+          renderOnZeroPageCount={null}
+          containerClassName={styles["pagination"]}
+          activeClassName={styles["pagination-active"]}
+          pageClassName={styles["page-item"]}
+          previousClassName={styles["page-item"]}
+          nextClassName={styles["page-item"]}
+          breakClassName={styles["page-item"]}
+        />
         <ToastContainer />
       </div>
     </div>

--- a/frontend/toge-trades/src/Pages/Trade-hub/TradeHubPage.jsx
+++ b/frontend/toge-trades/src/Pages/Trade-hub/TradeHubPage.jsx
@@ -3,6 +3,7 @@ import styles from "./TradeHubPage.module.css";
 import NewListing from "../../components/trade-hub/new-listing/NewListing";
 import { useState } from "react";
 import ListingSelectionModal from "../../components/trade-hub/new-listing/listing-selection/ListingSelectionModal";
+import { useListings } from "../../controllers/ListingsController";
 
 export default function TradeHubPage() {
   const [showOfferModal, setShowOffer] = useState(false);
@@ -13,6 +14,11 @@ export default function TradeHubPage() {
 
   const { page } = useParams();
   const navigate = useNavigate();
+  const initialPage = page ? parseInt(page, 10) : 1;
+  const [currentPage, setCurrentPage] = useState(initialPage);
+  const { listings, isLoading, error, refresh, listingsMetadata } =
+    useListings(currentPage);
+  if (error) toast.error(error);
 
   // ----- Offer/seek modal handling ----
   const openListingSelectionModal = (isOffered) => {

--- a/frontend/toge-trades/src/Pages/Trade-hub/TradeHubPage.jsx
+++ b/frontend/toge-trades/src/Pages/Trade-hub/TradeHubPage.jsx
@@ -4,6 +4,10 @@ import NewListing from "../../components/trade-hub/new-listing/NewListing";
 import { useState } from "react";
 import ListingSelectionModal from "../../components/trade-hub/new-listing/listing-selection/ListingSelectionModal";
 import { useListings } from "../../controllers/ListingsController";
+import "ldrs/infinity";
+import ReactPaginate from "react-paginate";
+import { ToastContainer } from "react-toastify";
+import ListingCards from "../../components/trade-hub/listing-cards/ListingCards";
 
 export default function TradeHubPage() {
   const [showOfferModal, setShowOffer] = useState(false);
@@ -87,7 +91,28 @@ export default function TradeHubPage() {
           <h3>Recent Listings</h3>
           <button>Refresh</button>
         </div>
-        <div className={styles["hub-listings"]}></div>
+        <div className={styles["hub-listings"]}>
+          {listings.map((listing) => (
+            <ListingCards
+              key={listing.id}
+              listing={listing}
+              // isInMyListings={true}
+            />
+          ))}
+          {isLoading && (
+            <div className="pokebox-loader">
+              <l-infinity
+                size="55"
+                stroke="4"
+                stroke-length="0.15"
+                bg-opacity="0.1"
+                speed="1.3"
+                color="#78A7E2"
+              />
+            </div>
+          )}
+        </div>
+        <ToastContainer />
       </div>
     </div>
   );

--- a/frontend/toge-trades/src/Pages/Trade-hub/TradeHubPage.module.css
+++ b/frontend/toge-trades/src/Pages/Trade-hub/TradeHubPage.module.css
@@ -25,6 +25,9 @@
   justify-self: center;
   align-self: center;
 }
+.hub-title-listings{
+  width: 30em;
+}
 .hub-title-listings button{
   width:8em;
   justify-self: flex-end;
@@ -35,4 +38,12 @@
 .hub-listings{
   display:flex;
   flex-direction: rows;
+ 
+}
+
+/* Mobile format */
+@media screen and (max-width: 715px) {
+  .hub-title-listings{
+    width: 100%;
+  }
 }

--- a/frontend/toge-trades/src/Pages/Trade-hub/TradeHubPage.module.css
+++ b/frontend/toge-trades/src/Pages/Trade-hub/TradeHubPage.module.css
@@ -36,8 +36,12 @@
   justify-self: flex-start;
 }
 .hub-listings{
+  margin-top: 01em;
   display:flex;
-  flex-direction: rows;
+  flex-direction: column;
+  gap: 1em;
+  width: 40em;
+  justify-self: center;
  
 }
 

--- a/frontend/toge-trades/src/Pages/Trade-hub/TradeHubPage.module.css
+++ b/frontend/toge-trades/src/Pages/Trade-hub/TradeHubPage.module.css
@@ -36,7 +36,7 @@
   justify-self: flex-start;
 }
 .hub-listings{
-  margin-top: 01em;
+  margin-top: 1em;
   display:flex;
   flex-direction: column;
   gap: 1em;
@@ -45,9 +45,59 @@
  
 }
 
+.pagination-item{
+  padding: 0.5em;
+  border-radius: 1em;
+  transition: all 0.3s ease; 
+  cursor: pointer;
+}
+.pagination-item img{
+  height: 4em;
+  width: 4em;
+}
+.pagination-item:hover {
+  background-color: #C9DCF4;
+}
+.pagination-item.selected {
+  border: 0.2em solid #78A7E2; 
+  box-shadow: 0 0 10px rgba(120, 167, 226, 0.5); 
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  list-style-type: none;
+  padding: 0.4em;
+}
+
+.page-item {
+  margin: 0 0.6em;
+  padding: 0.3em;
+}
+
+.page-item a {
+  text-decoration: none;
+  color: #616980;
+  padding: 0.6em 0.9em;
+  border-radius: 0.5em;
+}
+
+.page-item a:hover {
+  background-color: #78A7E2; 
+  color: white; 
+}
+
+.pagination-active a{
+  background-color: #78A7E2;
+  color: white;
+}
+
 /* Mobile format */
 @media screen and (max-width: 715px) {
   .hub-title-listings{
+    width: 100%;
+  }
+  .hub-listings{
     width: 100%;
   }
 }

--- a/frontend/toge-trades/src/components/global-navigation/user-dropdown/UserDropDown.css
+++ b/frontend/toge-trades/src/components/global-navigation/user-dropdown/UserDropDown.css
@@ -43,6 +43,7 @@
   padding:0.5em;
   background-color: #C9DCF4;
   border-radius: 50%;
+  margin-right: 1em;
 }
 
 .heading-username{

--- a/frontend/toge-trades/src/components/trade-hub/listing-cards/ListingCards.jsx
+++ b/frontend/toge-trades/src/components/trade-hub/listing-cards/ListingCards.jsx
@@ -8,7 +8,7 @@ export default function ListingCards({ listing, isInMyListings = false }) {
   return (
     <div className={styles["listing-card-container"]}>
       <div className={styles["title"]}>
-        <h3>{`Listing #${listing.listingNum}`}</h3>
+        <h3>{`Listing #${listing.listingNum.toString().padStart(4, "0")}`}</h3>
         {isInMyListings ? (
           <div
             className={`${styles["listing-status"]} ${

--- a/frontend/toge-trades/src/components/trade-hub/listing-cards/ListingCards.jsx
+++ b/frontend/toge-trades/src/components/trade-hub/listing-cards/ListingCards.jsx
@@ -1,4 +1,4 @@
-import TradeTransferIcons from "../trade-transfer-icons/ListingTradeIcons";
+import ListingTradeIcons from "../trade-transfer-icons/ListingTradeIcons";
 import styles from "./ListingCards.module.css";
 
 export default function ListingCards({ listing, isInMyListings = false }) {
@@ -25,7 +25,7 @@ export default function ListingCards({ listing, isInMyListings = false }) {
         )}
       </div>
       <div className={styles["trades"]}>
-        <TradeTransferIcons
+        <ListingTradeIcons
           offered={listing.offeringPokemon}
           seeking={listing.seekingSpecies}
           isSeekingShiny={listing.isSeekingShiny}

--- a/frontend/toge-trades/src/components/trade-hub/listing-cards/ListingCards.jsx
+++ b/frontend/toge-trades/src/components/trade-hub/listing-cards/ListingCards.jsx
@@ -1,0 +1,39 @@
+import TradeTransferIcons from "../trade-transfer-icons/ListingTradeIcons";
+import styles from "./ListingCards.module.css";
+
+export default function ListingCards({ listing, isInMyListings = false }) {
+  const handleOnClick = () => {
+    console.log("i clicked");
+  };
+  return (
+    <div className={styles["listing-card-container"]}>
+      <div className={styles["title"]}>
+        <h3>{`Listing #${listing.listingNum}`}</h3>
+        {isInMyListings ? (
+          <div
+            className={`${styles["listing-status"]} ${
+              listing.status === "Active" ? styles["active"] : ""
+            }  `}
+          >
+            <p>{listing.status}</p>
+          </div>
+        ) : (
+          <div className={styles["user"]}>
+            <img src={listing.listedBy.image} />
+            <p>{listing.listedBy.username}</p>
+          </div>
+        )}
+      </div>
+      <div className={styles["trades"]}>
+        <TradeTransferIcons
+          offered={listing.offeringPokemon}
+          seeking={listing.seekingSpecies}
+          isSeekingShiny={listing.isSeekingShiny}
+        />
+      </div>
+      <div className={styles["listing-btn"]}>
+        <button onClick={handleOnClick}>View Listing</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/toge-trades/src/components/trade-hub/listing-cards/ListingCards.module.css
+++ b/frontend/toge-trades/src/components/trade-hub/listing-cards/ListingCards.module.css
@@ -8,13 +8,14 @@
   justify-content: flex-start;
   align-items: center;
   border-radius: 2em;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25); 
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  gap: 1em;
 }
 .title{
   display:flex;
   flex-direction: column;
-  padding-left: 2em;
-  padding-right: 2em;
+  margin-left: 1em;
+  width: 10em;
 }
 .title h3{
   text-align: left;
@@ -52,7 +53,8 @@
   flex-grow: 1;
 }
 .listing-btn{
-  padding: 1em;
+  padding: 0.5em;
+  width: 10em;
 }
 .listing-btn button{
   border-color: #5988D8;

--- a/frontend/toge-trades/src/components/trade-hub/listing-cards/ListingCards.module.css
+++ b/frontend/toge-trades/src/components/trade-hub/listing-cards/ListingCards.module.css
@@ -1,0 +1,70 @@
+.listing-card-container{
+  position: relative;
+  background-color: #FFFFFF;
+  width:100%;
+  height: 10em;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  border-radius: 2em;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25); 
+}
+.title{
+  display:flex;
+  flex-direction: column;
+  padding-left: 2em;
+  padding-right: 2em;
+}
+.title h3{
+  text-align: left;
+}
+.listing-status{
+  display: inline-block;
+  padding: 0.1em 2em;
+  border-radius: 1.5em;
+  font-size: 1em;
+  background-color: #616980;
+  line-height: 0;
+  white-space: nowrap;
+  color: white;
+}
+.active{
+  background-color: #6EBB6E;
+}
+.user{
+  width: 6em;
+}
+.user img{
+  width: 35%;
+  background-color: #E1EBF8;
+  padding: 0.5em;
+  border-radius: 50%;
+  margin-bottom: 0;
+}
+.user p{
+  line-height: 0;
+}
+.trades{
+  display:flex;
+  justify-content: center;
+  align-self: center;
+  flex-grow: 1;
+}
+.listing-btn{
+  padding: 1em;
+}
+.listing-btn button{
+  border-color: #5988D8;
+  border-width: 0.15em;
+  background-color: #ffffff;
+  color: #212A4A;
+  font-size: 1em;
+  padding: 0.4em 1em;
+  border-radius: 1em;
+
+}
+
+.listing-btn button:hover{
+  background-color: #F2F6FC;
+}

--- a/frontend/toge-trades/src/components/trade-hub/listing-cards/ListingCards.module.css
+++ b/frontend/toge-trades/src/components/trade-hub/listing-cards/ListingCards.module.css
@@ -68,3 +68,41 @@
 .listing-btn button:hover{
   background-color: #F2F6FC;
 }
+
+/* Mobile format */
+@media screen and (max-width: 715px) {
+  .listing-card-container{
+    width: 100%;
+    height: auto;
+    flex-direction: column;
+    justify-content: center;
+  }
+  .title{
+    margin-top: 2em;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    width: 80%;
+    margin-bottom: 1em;
+  }
+  .title h3{
+    text-align: left;
+  }
+  .user{
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+  .user img{
+    margin-right: 0.5em;
+  }
+  .listing-btn{
+    width: 90%;
+  }
+  .listing-btn button{
+    width: 100%;
+  }
+  .trades{
+    width:90%
+  }
+}

--- a/frontend/toge-trades/src/components/trade-hub/new-listing/NewListing.jsx
+++ b/frontend/toge-trades/src/components/trade-hub/new-listing/NewListing.jsx
@@ -61,7 +61,9 @@ export default function NewListing({ onClicked, pokemon, species, isShinyWanted,
           />
         </div>
         <div className={styles["new-listing-button"]}>
-          <button onClick={handleCreateListing}>Create New Listing</button>
+          <button onClick={handleCreateListing} disabled={!pokemon || !species}>
+            Create New Listing
+          </button>
         </div>
         <ToastContainer />
       </div>

--- a/frontend/toge-trades/src/components/trade-hub/new-listing/infinite-scroll/InfiniteScroll.module.css
+++ b/frontend/toge-trades/src/components/trade-hub/new-listing/infinite-scroll/InfiniteScroll.module.css
@@ -20,7 +20,6 @@
   background-color: #E1EBF8;
 }
 
-
 .item.selected {
   border: 0.2em solid #78A7E2; 
   box-shadow: 0 0 10px rgba(120, 167, 226, 0.5); 
@@ -29,4 +28,16 @@
 .item img{
   height: 4em;
   width: 4em;
+}
+/* Mobile format */
+@media screen and (max-width: 715px) {
+  .scroll-grid{
+    display:grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.5em;
+    width: 100%;
+  }
+  .item {
+    padding:0.5em
+  }
 }

--- a/frontend/toge-trades/src/components/trade-hub/new-listing/listing-selection/ListingSelectionModal.module.css
+++ b/frontend/toge-trades/src/components/trade-hub/new-listing/listing-selection/ListingSelectionModal.module.css
@@ -26,7 +26,7 @@
   position:relative;
   background: white;
   border-radius: 2em;
-  padding:1.5rem;
+  padding:1.5em;
   width: 45em;
   height: 30em;
   transform: translateY(-20px);
@@ -121,4 +121,63 @@
 }
 .selection-modal-button button{
   width: 100%;
+}
+
+/* Mobile format */
+@media screen and (max-width: 715px) {
+  .selection-modal-title h2{
+    padding-right: 0.2em;
+    font-size: 1.1em;
+  }
+  .modal{
+    width: 80%;
+    height: 70%;
+    top: 2em;
+  }
+  .selection-modal-poke-pagination{
+    display:grid;
+    grid-template-columns: repeat(3, 1fr);
+    overflow-y: auto;
+    height: 65%;
+
+  }
+  .pagination-item {
+    padding: 0.2em;
+    background-color: pink;
+  }
+  .pagination-item img{
+    width: 3.5em;
+    height: 3.5em;
+  }
+  .pagination {
+    margin-top: 0.2em;
+    
+  }
+  .selection-modal-button{
+    margin-top: 0;
+  }
+  .seeking-shiny{
+    margin-top: 1em;
+    margin-bottom: 1em;
+  }
+  .seeking-shiny h3{
+    font-size: 0.95em;
+
+  }
+
+}
+/* Tablet format */
+@media screen and (max-width: 988px) and (min-width:715px ) {
+  .modal{
+    width: 35em;
+    height: 28em;
+    top: 2em;
+  }
+  .pagination {
+    margin-top: 2em;
+    
+  }
+  .selection-modal-button{
+    margin-top: 0;
+  }
 }

--- a/frontend/toge-trades/src/components/trade-hub/trade-transfer-icons/ListingTradeIcons.jsx
+++ b/frontend/toge-trades/src/components/trade-hub/trade-transfer-icons/ListingTradeIcons.jsx
@@ -1,0 +1,57 @@
+import { capitalizeFirstLetter } from "../../utils/utils";
+import styles from "./ListingTradeIcons.module.css";
+import { Tooltip } from "react-tooltip";
+import { BsStars } from "react-icons/bs";
+
+export default function TradeTransferIcons({
+  offered,
+  seeking,
+  isSeekingShiny,
+}) {
+  return (
+    <div className={styles["trade-transfer-icon-container"]}>
+      <div className={styles["offered"]}>
+        <div className={styles["image-container"]}>
+          {offered.isShiny ? (
+            <a
+              data-tooltip-id="listing-trade-tooltips"
+              data-tooltip-content="Shiny Pokemon"
+            >
+              <BsStars className={`${styles["shiny-star"]}`} />
+            </a>
+          ) : null}
+          <img
+            src={
+              offered.isShiny
+                ? offered.species.image.shiny
+                : offered.species.image.normal
+            }
+          />
+        </div>
+        <p>{`Offers ${capitalizeFirstLetter(offered.species.name)}`}</p>
+      </div>
+      <img
+        src="../../../src/assets/trade-icon.png"
+        className={styles["trade-icon"]}
+      />
+      <div className={styles["seeking"]}>
+        <div className={styles["image-container"]}>
+          {isSeekingShiny ? (
+            <a
+              data-tooltip-id="listing-trade-tooltips"
+              data-tooltip-content="Shiny Pokemon"
+            >
+              <BsStars className={`${styles["shiny-star"]}`} />
+            </a>
+          ) : null}
+          <img
+            src={isSeekingShiny ? seeking.image.shiny : seeking.image.normal}
+          />
+        </div>
+
+        <p>{`Seeks ${capitalizeFirstLetter(seeking.name)}`}</p>
+      </div>
+      <Tooltip id="listing-trade-tooltips" />
+    </div>
+  );
+}

--- a/frontend/toge-trades/src/components/trade-hub/trade-transfer-icons/ListingTradeIcons.jsx
+++ b/frontend/toge-trades/src/components/trade-hub/trade-transfer-icons/ListingTradeIcons.jsx
@@ -3,7 +3,7 @@ import styles from "./ListingTradeIcons.module.css";
 import { Tooltip } from "react-tooltip";
 import { BsStars } from "react-icons/bs";
 
-export default function TradeTransferIcons({
+export default function ListingTradeIcons({
   offered,
   seeking,
   isSeekingShiny,

--- a/frontend/toge-trades/src/components/trade-hub/trade-transfer-icons/ListingTradeIcons.module.css
+++ b/frontend/toge-trades/src/components/trade-hub/trade-transfer-icons/ListingTradeIcons.module.css
@@ -1,0 +1,50 @@
+.trade-transfer-icon-container{
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 1.5em;
+  width: 19em;
+}
+.offered, .seeking p{
+  line-height: 1;
+  text-align: center; 
+  white-space: normal; 
+  word-wrap: break-word; 
+}
+.offered img{
+  background-color: #C9DCF4;
+}
+.trade-icon{
+  width: 2em;
+  height: 2em;
+}
+.offered, .seeking {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+.image-container {
+  position: relative;
+  display: inline-block;
+  width: 4em;
+
+}
+.seeking img{
+  background-color: #F4E1C9;
+}
+
+.image-container img {
+  display: block;
+  width: 100%; 
+  border-radius: 50%;
+  padding: 0.5em;
+}
+.shiny-star{
+  position:absolute;
+  top:0;
+  left: 0;
+  color: #88A0E6;
+  font-size: 1.5em;
+}

--- a/frontend/toge-trades/src/components/trade-hub/trade-transfer-icons/ListingTradeIcons.module.css
+++ b/frontend/toge-trades/src/components/trade-hub/trade-transfer-icons/ListingTradeIcons.module.css
@@ -14,6 +14,7 @@
 }
 .offered img{
   background-color: #C9DCF4;
+  justify-self: center;
 }
 .trade-icon{
   width: 2em;
@@ -23,16 +24,16 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
 }
 .image-container {
   position: relative;
   display: inline-block;
-  width: 4em;
+  width: 4em; 
 
 }
 .seeking img{
   background-color: #F4E1C9;
+  justify-self: center;
 }
 
 .image-container img {

--- a/frontend/toge-trades/src/components/trade-hub/trade-transfer-icons/ListingTradeIcons.module.css
+++ b/frontend/toge-trades/src/components/trade-hub/trade-transfer-icons/ListingTradeIcons.module.css
@@ -4,7 +4,7 @@
   justify-content: center;
   align-items: center;
   gap: 1.5em;
-  width: 19em;
+  width: 100%;
 }
 .offered, .seeking p{
   line-height: 1;
@@ -47,4 +47,14 @@
   left: 0;
   color: #88A0E6;
   font-size: 1.5em;
+}
+
+@media screen and (max-width: 715px) {
+  .trade-icon{
+    width: 1.5em;
+    height: 1.5em;
+  }
+  .image-container {
+    width: 3em;
+  }
 }

--- a/frontend/toge-trades/src/controllers/ListingsController.jsx
+++ b/frontend/toge-trades/src/controllers/ListingsController.jsx
@@ -59,7 +59,7 @@ export function useListings(currentPage) {
   useEffect(() => {
     if (rawData.success) {
       let listingsData = rawData.data;
-      setListingsMetadata(listingsData.metadata);
+      setListingsMetadata(rawData.metadata);
 
       const listingModels = listingsData.map((data) =>
         ListingModel.fromJSON(data)

--- a/frontend/toge-trades/src/controllers/ListingsController.jsx
+++ b/frontend/toge-trades/src/controllers/ListingsController.jsx
@@ -3,7 +3,11 @@ import { allEligiblePokemon, createListing } from "../api/api";
 import { useAuth } from "../api/auth";
 import PokemonModel from "../models/PokemonModel";
 import { toast } from "react-toastify";
+import useGet from "../hooks/useGet";
+import { LISTING_URL } from "../api/urls";
+import ListingModel from "../models/ListingModel";
 
+// ---- Fetches all elgible pokemon that user has ----
 export function getEligibleTradePokemon(page = 1) {
   return allEligiblePokemon(page)
     .then((res) => {
@@ -23,6 +27,7 @@ export function getEligibleTradePokemon(page = 1) {
     });
 }
 
+// ---- Creates a new listing ----
 export function createNewListing(pokeId, speciesId, isSeekingShiny) {
   return createListing(pokeId, speciesId, isSeekingShiny)
     .then((res) => {
@@ -38,4 +43,29 @@ export function createNewListing(pokeId, speciesId, isSeekingShiny) {
           (e.response?.data?.message || "An unexpected error occurred")
       );
     });
+}
+
+// ---- Fetches all listings sorted by recency ----
+export function useListings(currentPage) {
+  const {
+    data: rawData,
+    isLoading,
+    error,
+    refresh,
+  } = useGet(LISTING_URL, [], true, true, currentPage);
+  const [listings, setListings] = useState([]);
+  const [listingsMetadata, setListingsMetadata] = useState({});
+
+  useEffect(() => {
+    if (rawData.success) {
+      let listingsData = rawData.data;
+      setListingsMetadata(listingsData.metadata);
+
+      const listingModels = listingsData.map((data) =>
+        ListingModel.fromJSON(data)
+      );
+      setListings(listingModels);
+    }
+  }, [rawData]);
+  return { listings, isLoading, error, refresh, listingsMetadata };
 }

--- a/frontend/toge-trades/src/models/ListingModel.jsx
+++ b/frontend/toge-trades/src/models/ListingModel.jsx
@@ -1,0 +1,55 @@
+import OffersModel from "./OffersModel";
+import PokemonModel from "./PokemonModel";
+import SpeciesModel from "./SpeciesModel";
+import UserModel from "./UserModel";
+
+class ListingModel {
+  constructor(
+    id,
+    listingNum,
+    offeringPokemon,
+    seekingSpecies,
+    isSeekingShiny,
+    listedBy,
+    dateCreated,
+    status,
+    offers,
+    acceptedOffer
+  ) {
+    this.id = id;
+    this.listingNum = listingNum;
+    this.offeringPokemon = offeringPokemon;
+    this.seekingSpecies = seekingSpecies;
+    this.isSeekingShiny = isSeekingShiny;
+    this.listedBy = listedBy;
+    this.dateCreated = new Date(dateCreated);
+    this.status = status;
+    this.offers = offers || [];
+    this.acceptedOffer = acceptedOffer || null;
+  }
+  static fromJSON(data) {
+    let acceptedOffer = null;
+    let offers = [];
+    if (data.acceptedOffer) {
+      OffersModel.fromJSON(data.acceptedOffer);
+    }
+    if (data.offers.length > 0) {
+      offers = data.offers.map((offer) => OffersModel.fromJSON(offer));
+    }
+
+    return new ListingModel(
+      data._id,
+      data.listingNum,
+      PokemonModel.fromJSON(data.offeringPokemon),
+      SpeciesModel.fromJSON(data.seekingSpecies),
+      data.isSeekingShiny,
+      UserModel.fromJSON(data.listedBy),
+      data.dateCreated,
+      data.status,
+      offers,
+      acceptedOffer
+    );
+  }
+}
+
+export default ListingModel;

--- a/frontend/toge-trades/src/models/OffersModel.jsx
+++ b/frontend/toge-trades/src/models/OffersModel.jsx
@@ -1,0 +1,40 @@
+import ListingModel from "./ListingModel";
+import PokemonModel from "./PokemonModel";
+import SpeciesModel from "./SpeciesModel";
+import UserModel from "./UserModel";
+
+class OffersModel {
+  constructor(
+    id,
+    offerNum,
+    offeredPokemon,
+    listing,
+    offeredBy,
+    status,
+    dateCreated,
+    dateAccepted
+  ) {
+    this.id = id;
+    this.offerNum = offerNum;
+    this.offeredPokemon = offeredPokemon;
+    this.listing = listing;
+    this.offeredBy = offeredBy;
+    this.status = status;
+    this.dateCreated = new Date(dateCreated);
+    this.dateAccepted = new Date(dateAccepted) || null;
+  }
+  static fromJSON(data) {
+    return new OffersModel(
+      data._id,
+      data.offerNum,
+      PokemonModel.fromJSON(data.offeredPokemon),
+      ListingModel.fromJSON(data.listing),
+      UserModel.fromJSON(data.offeredBy),
+      data.dateCreated,
+      data.status,
+      data.dateAccepted
+    );
+  }
+}
+
+export default OffersModel;


### PR DESCRIPTION
Recent listing feature: 
- Can now show recent listings with pagination, NOTE: clicking on view listing button doesn't lead to anywhere yet

Other fixes:
- [FIX KB-20: Changed default limit to 10 when fetching all listings](https://github.com/rnat697/togetrades/commit/911c11296cd8c6ca47795e914d3357bad9667e9a)
- [FEAT KB-19: Added api call to GET /api/v1/listings/ in trade hub page](https://github.com/rnat697/togetrades/commit/277338712e7e7de9127a0526e3225d3494441046)
- [FIX KB-22: Added responsiveness to listing selection modal](https://github.com/rnat697/togetrades/commit/a433365143869b01e8e91d39d3c28e5fe1940b7f)
